### PR TITLE
ci: add guarded Renovate automerge

### DIFF
--- a/.github/workflows/promote-develop-to-main.yml
+++ b/.github/workflows/promote-develop-to-main.yml
@@ -1,0 +1,90 @@
+# yamllint disable rule:truthy
+---
+name: Promote develop to main
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  promote:
+    name: Open develop-to-main promotion PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create or update promotion PR and enable auto-merge
+        env:
+          ACTIONS_TOKEN: ${{ github.token }}
+          RELEASE_TOKEN: ${{ secrets.LITRELEASEBOT_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RELEASE_TOKEN:-}" ]; then
+            echo "LITRELEASEBOT_TOKEN is required to create PRs and enable auto-merge."
+            exit 1
+          fi
+
+          if ! git ls-remote --exit-code --heads origin develop >/dev/null 2>&1; then
+            echo "develop branch does not exist; skipping promotion."
+            exit 0
+          fi
+
+          git fetch origin main develop
+
+          if git merge-base --is-ancestor origin/develop origin/main; then
+            echo "main already contains develop; skipping promotion."
+            exit 0
+          fi
+
+          title="chore(release): promote develop to main"
+          body=$'Weekly promotion PR from `develop` to `main`.\n\n'
+          body+=$'This PR must merge only after required checks pass. '
+          body+=$'GitHub auto-merge is enabled by this workflow.'
+
+          pr_url="$(GH_TOKEN="$RELEASE_TOKEN" gh pr list \
+            --repo "$REPO" \
+            --base main \
+            --head develop \
+            --state open \
+            --json url \
+            --jq '.[0].url')"
+
+          if [ -z "$pr_url" ]; then
+            pr_url="$(GH_TOKEN="$RELEASE_TOKEN" gh pr create \
+              --repo "$REPO" \
+              --base main \
+              --head develop \
+              --title "$title" \
+              --body "$body")"
+          else
+            GH_TOKEN="$RELEASE_TOKEN" gh pr edit "$pr_url" \
+              --repo "$REPO" \
+              --title "$title" \
+              --body "$body"
+          fi
+
+          approved_count="$(GH_TOKEN="$ACTIONS_TOKEN" gh pr view "$pr_url" \
+            --repo "$REPO" \
+            --json reviews \
+            --jq '[.reviews[] | select(.author.login == "github-actions[bot]" and .state == "APPROVED")] | length')"
+
+          if [ "$approved_count" -eq 0 ]; then
+            GH_TOKEN="$ACTIONS_TOKEN" gh pr review "$pr_url" \
+              --repo "$REPO" \
+              --approve \
+              --body "Approved trusted weekly develop-to-main promotion created by automation."
+          fi
+
+          GH_TOKEN="$RELEASE_TOKEN" gh pr merge "$pr_url" --repo "$REPO" --auto --merge

--- a/.github/workflows/renovate-guarded-automerge.yml
+++ b/.github/workflows/renovate-guarded-automerge.yml
@@ -1,0 +1,74 @@
+# yamllint disable rule:truthy
+---
+name: Renovate guarded automerge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  approve-renovate:
+    name: Approve trusted Renovate PR
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Verify Renovate PR identity
+        id: guard
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          TRIGGER_ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+
+          labels="$(jq -r '.[]' <<<"$PR_LABELS")"
+
+          has_label() {
+            grep -Fxq "$1" <<<"$labels"
+          }
+
+          trusted=true
+
+          if [ "$TRIGGER_ACTOR" != "renovate[bot]" ]; then
+            trusted=false
+          fi
+
+          if [ "$PR_AUTHOR" != "renovate[bot]" ]; then
+            trusted=false
+          fi
+
+          case "$PR_HEAD" in
+            renovate/*) ;;
+            *) trusted=false ;;
+          esac
+
+          if [ "$PR_BASE" != "develop" ]; then
+            trusted=false
+          fi
+
+          if ! has_label renovate || ! has_label dependencies; then
+            trusted=false
+          fi
+
+          echo "trusted=$trusted" >>"$GITHUB_OUTPUT"
+
+      - name: Approve and enable auto-merge
+        if: steps.guard.outputs.trusted == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+
+          gh pr review "$PR_URL" \
+            --approve \
+            --body "Approved trusted Renovate dependency update after actor, label, branch, and base-branch checks."
+
+          gh pr merge "$PR_URL" --auto --merge

--- a/AGENT.md
+++ b/AGENT.md
@@ -91,6 +91,44 @@ If generic guidance conflicts with repository behavior, you MUST prefer reposito
 5. Do not create parallel version ownership for the same dependency across multiple files unless the repository
    explicitly documents that split.
 
+## 2.3 Ansible Collection Renovate and Release Policy
+
+For Lightning IT Ansible collection repositories, follow the shared Renovate and release model.
+
+Do not duplicate generic Renovate policy in individual collection repositories. Generic Renovate rules must be
+maintained in `lightning-it/shared-assets` and consumed through the repository's `renovate.json` `extends`
+configuration.
+
+Collection repositories may only define repository-specific Renovate overrides, such as:
+
+- temporary version pins
+- compatibility constraints
+- collection-specific package rules
+- local custom managers that are not reusable
+
+The standard branch and release model is:
+
+- `develop` is the automated integration branch.
+- Renovate targets `develop`.
+- Safe patch, minor, pin, and digest updates may auto-merge into `develop` after required CI passes.
+- Major updates require manual approval.
+- `main` is the stable release branch.
+- `develop` must not be configured as a semantic-release branch unless an explicit pre-release strategy is
+  requested.
+- Weekly promotion from `develop` to `main` must happen through a pull request.
+- Weekly promotion may use GitHub auto-merge, but must not bypass required checks.
+- Do not direct-push from `develop` to `main`.
+- semantic-release must remain main-only for stable releases.
+
+Automation safety requirements:
+
+- Protected branches must require pull request review.
+- Only trusted Renovate PRs may be auto-approved by collection automation.
+- A trusted Renovate PR must have `renovate[bot]` as both trigger actor and PR author, a `renovate/*` source
+  branch, `develop` as the base branch, and both `renovate` and `dependencies` labels.
+- Human and external contributor PRs must not be auto-approved or auto-merged by collection automation.
+- Do not use `pull_request_target` for Renovate approval or merge automation.
+
 ## 3. Role Variable Naming and Mapping Rules
 
 ### 3.1 Role-Prefixed Variables (Mandatory)


### PR DESCRIPTION
## Summary
- add guarded Renovate auto-approval/automerge workflow
- add weekly develop-to-main promotion workflow
- document persistent agent instructions for the guarded automation model

## Verification
- yamllint .github/workflows/renovate-guarded-automerge.yml .github/workflows/promote-develop-to-main.yml
- actionlint .github/workflows/renovate-guarded-automerge.yml .github/workflows/promote-develop-to-main.yml
- git diff --check