### PR TITLE
test: verify collection release workflow after back-sync fix

### DIFF
--- a/changelogs/fragments/release-verification-3.yml
+++ b/changelogs/fragments/release-verification-3.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - lit.ocp - Verify automated collection release workflow after final back-sync race fix.


### PR DESCRIPTION
Adds a minimal changelog fragment to verify the final release back-sync race fix in the repo that reproduced the duplicate PR creation race.