### PR TITLE
ci: require Galaxy publishing for collection releases

### DIFF
--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -110,9 +110,11 @@ jobs:
                 && contains(github.event.pull_request.body, 'Galaxy publishing: `true`')
               )
             }}
-          GALAXY_API_TOKEN: ${{ secrets.GALAXY_API_TOKEN || secrets.ANSIBLE_GALAXY_API_KEY }}
+          GALAXY_API_TOKEN: ${{ secrets.GALAXY_API_TOKEN }}
+          ANSIBLE_GALAXY_API_KEY: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
         run: |
           set -euo pipefail
+          GALAXY_API_TOKEN="${GALAXY_API_TOKEN:-${ANSIBLE_GALAXY_API_KEY:-}}"
 
           version="$(python - <<'PY'
           import yaml

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -5,7 +5,7 @@ name: Publish collection release
 on:
   pull_request:
     types: [closed]
-    branches: ["main"]
+    branches: ["develop"]
     paths:
       - galaxy.yml
       - CHANGELOG.rst
@@ -72,10 +72,10 @@ jobs:
           fi
           echo "value=${{ github.token }}" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout main
+      - name: Checkout develop
         uses: actions/checkout@v7
         with:
-          ref: main
+          ref: develop
           token: ${{ steps.token.outputs.value }}
           fetch-depth: 0
 
@@ -150,9 +150,9 @@ jobs:
             if gh release view "$tag" >/dev/null 2>&1; then
               echo "GitHub release $tag already exists; leaving it unchanged."
             else
-              gh release create "$tag" "$tarball" --target main --title "$tag" --notes-file "$notes"
+              gh release create "$tag" "$tarball" --target develop --title "$tag" --notes-file "$notes"
             fi
-            gh workflow run release-back-sync.yml --ref main -f tag="$tag"
+            echo "Release published from develop; release back-sync is not required."
           else
             echo "GitHub release creation disabled for this release."
           fi

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -5,7 +5,7 @@ name: Publish collection release
 on:
   pull_request:
     types: [closed]
-    branches: ["develop"]
+    branches: ["main"]
     paths:
       - galaxy.yml
       - CHANGELOG.rst
@@ -72,10 +72,10 @@ jobs:
           fi
           echo "value=${{ github.token }}" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout develop
+      - name: Checkout main
         uses: actions/checkout@v7
         with:
-          ref: develop
+          ref: main
           token: ${{ steps.token.outputs.value }}
           fetch-depth: 0
 
@@ -150,9 +150,9 @@ jobs:
             if gh release view "$tag" >/dev/null 2>&1; then
               echo "GitHub release $tag already exists; leaving it unchanged."
             else
-              gh release create "$tag" "$tarball" --target develop --title "$tag" --notes-file "$notes"
+              gh release create "$tag" "$tarball" --target main --title "$tag" --notes-file "$notes"
             fi
-            echo "Release published from develop; release back-sync is not required."
+            gh workflow run release-back-sync.yml --ref main -f tag="$tag"
           else
             echo "GitHub release creation disabled for this release."
           fi

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -39,6 +39,7 @@ jobs:
       )
     name: Publish collection release
     runs-on: ubuntu-latest
+    environment: ansible-collections
     env:
       RELEASE_BOT_APP_ID: ${{ secrets.RELEASE_BOT_APP_ID }}
       RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
@@ -109,7 +110,7 @@ jobs:
                 && contains(github.event.pull_request.body, 'Galaxy publishing: `true`')
               )
             }}
-          GALAXY_API_TOKEN: ${{ secrets.GALAXY_API_TOKEN }}
+          GALAXY_API_TOKEN: ${{ secrets.GALAXY_API_TOKEN || secrets.ANSIBLE_GALAXY_API_KEY }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -21,7 +21,7 @@ on:
       publish_galaxy:
         description: Publish to Ansible Galaxy.
         required: false
-        default: "false"
+        default: "true"
         type: choice
         options: ["true", "false"]
 
@@ -123,6 +123,15 @@ jobs:
           ansible-galaxy collection build --force
           tarball="$(ls ./*.tar.gz)"
 
+          if [ "$CREATE_GITHUB_RELEASE" = "true" ] && [ "$PUBLISH_GALAXY" != "true" ]; then
+            echo "::error::Collection releases must publish to Ansible Galaxy when creating a GitHub Release."
+            exit 1
+          fi
+          if [ "$PUBLISH_GALAXY" = "true" ] && [ -z "${GALAXY_API_TOKEN:-}" ]; then
+            echo "::error::GALAXY_API_TOKEN is required when publish_galaxy is true."
+            exit 1
+          fi
+
           notes="$(mktemp)"
           if [ ! -f CHANGELOG.rst ]; then
             echo "::error::CHANGELOG.rst is required for collection GitHub Release notes."
@@ -146,9 +155,5 @@ jobs:
           fi
 
           if [ "$PUBLISH_GALAXY" = "true" ]; then
-            if [ -z "${GALAXY_API_TOKEN:-}" ]; then
-              echo "::error::GALAXY_API_TOKEN is required when publish_galaxy is true."
-              exit 1
-            fi
             ansible-galaxy collection publish "$tarball" --api-key "$GALAXY_API_TOKEN"
           fi

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -29,7 +29,7 @@ on:
       publish_galaxy:
         description: Publish to Ansible Galaxy after merge.
         required: false
-        default: "false"
+        default: "true"
         type: choice
         options: ["true", "false"]
 
@@ -118,7 +118,7 @@ jobs:
           esac
           TARGET_BRANCH="${TARGET_BRANCH_INPUT:-main}"
           CREATE_GITHUB_RELEASE="${CREATE_GITHUB_RELEASE_INPUT:-true}"
-          PUBLISH_GALAXY="${PUBLISH_GALAXY_INPUT:-false}"
+          PUBLISH_GALAXY="${PUBLISH_GALAXY_INPUT:-true}"
 
           if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
             BASE_BRANCH="main"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -4,7 +4,7 @@ name: Prepare collection release
 
 on:
   push:
-    branches: ["main"]
+    branches: ["develop"]
   workflow_dispatch:
     inputs:
       version:
@@ -13,13 +13,13 @@ on:
         required: false
         default: ""
       base_branch:
-        description: Base branch. Leave empty to prefer develop, then main.
+        description: Base branch. Leave empty to use develop.
         required: false
         default: ""
       target_branch:
-        description: Release PR target branch. Must be main.
+        description: Release PR target branch. Must be develop.
         required: false
-        default: main
+        default: develop
       create_github_release:
         description: Create a GitHub release after merge.
         required: false
@@ -116,12 +116,12 @@ jobs:
           case "$VERSION" in
             v*) VERSION="${VERSION#v}" ;;
           esac
-          TARGET_BRANCH="${TARGET_BRANCH_INPUT:-main}"
+          TARGET_BRANCH="${TARGET_BRANCH_INPUT:-develop}"
           CREATE_GITHUB_RELEASE="${CREATE_GITHUB_RELEASE_INPUT:-true}"
           PUBLISH_GALAXY="${PUBLISH_GALAXY_INPUT:-true}"
 
           if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
-            BASE_BRANCH="main"
+            BASE_BRANCH="develop"
           elif [ -n "$BASE_BRANCH_INPUT" ]; then
             BASE_BRANCH="$BASE_BRANCH_INPUT"
           elif git ls-remote --exit-code --heads origin develop >/dev/null 2>&1; then
@@ -129,8 +129,8 @@ jobs:
           else
             BASE_BRANCH="$TARGET_BRANCH"
           fi
-          if [ "$TARGET_BRANCH" != "main" ]; then
-            echo "::error::Collection release PRs must target main."
+          if [ "$TARGET_BRANCH" != "develop" ]; then
+            echo "::error::Collection release PRs must target develop."
             exit 1
           fi
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -4,7 +4,7 @@ name: Prepare collection release
 
 on:
   push:
-    branches: ["develop"]
+    branches: ["main"]
   workflow_dispatch:
     inputs:
       version:
@@ -13,13 +13,13 @@ on:
         required: false
         default: ""
       base_branch:
-        description: Base branch. Leave empty to use develop.
+        description: Base branch. Leave empty to prefer develop, then main.
         required: false
         default: ""
       target_branch:
-        description: Release PR target branch. Must be develop.
+        description: Release PR target branch. Must be main.
         required: false
-        default: develop
+        default: main
       create_github_release:
         description: Create a GitHub release after merge.
         required: false
@@ -116,12 +116,12 @@ jobs:
           case "$VERSION" in
             v*) VERSION="${VERSION#v}" ;;
           esac
-          TARGET_BRANCH="${TARGET_BRANCH_INPUT:-develop}"
+          TARGET_BRANCH="${TARGET_BRANCH_INPUT:-main}"
           CREATE_GITHUB_RELEASE="${CREATE_GITHUB_RELEASE_INPUT:-true}"
           PUBLISH_GALAXY="${PUBLISH_GALAXY_INPUT:-true}"
 
           if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
-            BASE_BRANCH="develop"
+            BASE_BRANCH="main"
           elif [ -n "$BASE_BRANCH_INPUT" ]; then
             BASE_BRANCH="$BASE_BRANCH_INPUT"
           elif git ls-remote --exit-code --heads origin develop >/dev/null 2>&1; then
@@ -129,8 +129,8 @@ jobs:
           else
             BASE_BRANCH="$TARGET_BRANCH"
           fi
-          if [ "$TARGET_BRANCH" != "develop" ]; then
-            echo "::error::Collection release PRs must target develop."
+          if [ "$TARGET_BRANCH" != "main" ]; then
+            echo "::error::Collection release PRs must target main."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- default collection release PRs and manual publish runs to publish to Ansible Galaxy
- fail if a GitHub Release would be created without also publishing to Galaxy
- fail fast when Galaxy publishing is requested but GALAXY_API_TOKEN is unavailable

## Validation
- pre-commit run --all-files