### PR TITLE
docs: apply enterprise README standard

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,12 @@
+---
+config:
+  MD004: false
+  MD012: false
+  MD013: false
+  MD022: false
+  MD025: false
+  MD029: false
+  MD032: false
+  MD033: false
+  MD034: false
+  MD060: false

--- a/README.md
+++ b/README.md
@@ -10,28 +10,65 @@
 
 <!-- END LIT_QUALITY_BADGES -->
 
-<!-- BEGIN LIT_COMPATIBILITY_MATRIX -->
+`lit.ocp` is a Lightning IT Ansible Collection for reusable automation across ansible-core, openshift-client, incus.
 
-## Compatibility Matrix
+## Features
 
-| Collection Version | Role/Scenario | Platform | Product | Test Type | Validation |
-|---|---|---|---|---|---|
-| Current release | collection-sanity | ubuntu-latest | ansible-core, openshift-client, incus | Collection sanity | See GitHub Release evidence |
-| Current release | molecule-light | ubuntu-latest | ansible-core, openshift-client, incus | Molecule light | See GitHub Release evidence |
-| Current release | molecule-heavy-incus | ubuntu-latest | ansible-core, openshift-client, incus | Heavy Incus | See GitHub Release evidence |
-| Current release | galaxy-build | ubuntu-latest | ansible-core, openshift-client, incus | Galaxy build/publish | See GitHub Release evidence |
-| Current release | collection-sanity | rhel-9 | ansible-core, openshift-client, incus | Collection sanity | See GitHub Release evidence |
-| Current release | molecule-light | rhel-9 | ansible-core, openshift-client, incus | Molecule light | See GitHub Release evidence |
-| Current release | molecule-heavy-incus | rhel-9 | ansible-core, openshift-client, incus | Heavy Incus | See GitHub Release evidence |
-| Current release | galaxy-build | rhel-9 | ansible-core, openshift-client, incus | Galaxy build/publish | See GitHub Release evidence |
-| Current release | collection-sanity | rhel-10 | ansible-core, openshift-client, incus | Collection sanity | See GitHub Release evidence |
-| Current release | molecule-light | rhel-10 | ansible-core, openshift-client, incus | Molecule light | See GitHub Release evidence |
-| Current release | molecule-heavy-incus | rhel-10 | ansible-core, openshift-client, incus | Heavy Incus | See GitHub Release evidence |
-| Current release | galaxy-build | rhel-10 | ansible-core, openshift-client, incus | Galaxy build/publish | See GitHub Release evidence |
+- Reusable roles, modules, plugins, or playbook building blocks for Lightning IT automation.
+- Collection sanity validation and Molecule scenarios where configured.
+- GitHub Release evidence and Ansible Galaxy publishing where enabled.
 
-Validation proof for each released version is stored in the corresponding GitHub Release evidence.
+## Included Content
 
-<!-- END LIT_COMPATIBILITY_MATRIX -->
+| Content Type | Location |
+|---|---|
+| Roles | `roles/` |
+| Plugins and modules | `plugins/` where present |
+| Documentation | repository docs and Ansible Galaxy |
+
+## Requirements
+
+- Ansible Core compatible with the tested release matrix.
+- Supported products: `ansible-core, openshift-client, incus`.
+
+## Installation
+
+```bash
+ansible-galaxy collection install lit.ocp
+```
+
+## Quick Start
+
+```yaml
+- hosts: all
+  gather_facts: true
+  roles: []
+```
+
+## Examples
+
+See repository examples, role documentation, and release evidence for validated scenarios.
+
+## Documentation
+
+- [Ansible Galaxy](https://galaxy.ansible.com/ui/repo/published/lit/ocp/)
+- [RELEASE.md](./RELEASE.md)
+- [TESTING.md](./TESTING.md)
+- [SECURITY.md](./SECURITY.md)
+
+Opinionated Ansible roles for Red Hat OpenShift Container Platform: cluster bring-up, day-2 operations and platform services.
+
+## Security
+
+See [SECURITY.md](./SECURITY.md) for supported versions and vulnerability reporting.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution and review expectations.
+
+## License
+
+See [LICENSE](./LICENSE).
 
 <!-- BEGIN LIT_RELEASE_QUALITY_MODEL -->
 
@@ -39,7 +76,9 @@ Validation proof for each released version is stored in the corresponding GitHub
 
 This repository follows the Lightning IT shared release and quality model.
 The README shows the current supported and tested matrix.
-Exact per-version proof is stored with every GitHub Release as `release-evidence.md` and `release-evidence.json`.
+Exact per-version validation proof is stored with each GitHub Release as `release-evidence.md` and `release-evidence.json`.
+Releases are created from the protected `main` branch after a reviewed `develop -> main` release promotion.
+Collection releases validate collection sanity, Molecule scenarios, build integrity, and Ansible Galaxy publishing where enabled.
 
 See:
 
@@ -51,8 +90,38 @@ Repository classification: **Ansible Collection**.
 Required test profiles: `pre-commit, lint, light, molecule-light, molecule-heavy-incus, release-validation`.
 Publishing targets: `github-release, ansible-galaxy`.
 
-Release evidence records the exact GitHub Actions run, validated matrix rows, built artifacts, publish result, and security status for each release.
-
 <!-- END LIT_RELEASE_QUALITY_MODEL -->
 
-Opinionated Ansible roles for Red Hat OpenShift Container Platform: cluster bring-up, day-2 operations and platform services.
+<!-- BEGIN LIT_COMPATIBILITY_MATRIX -->
+
+## Compatibility Matrix
+
+| Collection Version | Platform | Product | Validation |
+|---|---|---|---|
+| Latest release | ubuntu-latest | ansible-core, openshift-client, incus | See release evidence |
+| Latest release | rhel-9 | ansible-core, openshift-client, incus | See release evidence |
+| Latest release | rhel-10 | ansible-core, openshift-client, incus | See release evidence |
+
+| Scenario | Test Type | Validation |
+|---|---|---|
+| collection-sanity | Collection sanity | See release evidence |
+| molecule-light | Molecule light | See release evidence |
+| molecule-heavy-incus | Heavy Incus | See release evidence |
+| galaxy-build | Galaxy build/publish | See release evidence |
+
+Validation proof for each released version is stored in the corresponding GitHub Release evidence.
+
+<!-- END LIT_COMPATIBILITY_MATRIX -->
+
+## Release Evidence
+
+Every released version includes immutable release evidence attached to the corresponding GitHub Release.
+The evidence records:
+
+- tested matrix combinations
+- GitHub Actions run links
+- artifact references
+- publish status
+- security scan status
+
+See [GitHub Releases](../../releases), [RELEASE.md](./RELEASE.md), and [TESTING.md](./TESTING.md) for the release process and validation model.

--- a/changelogs/fragments/enterprise-readme-standard.yml
+++ b/changelogs/fragments/enterprise-readme-standard.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - docs - Apply the shared enterprise README structure.


### PR DESCRIPTION
## Summary
- apply the shared enterprise README order with project content first and quality/audit sections near the bottom
- add managed `LIT_QUALITY_BADGES`, `LIT_RELEASE_QUALITY_MODEL`, and `LIT_COMPATIBILITY_MATRIX` blocks
- add the shared markdownlint-cli2 config for local README validation

## Validation
- `python3 scripts/audit-release-model.py` from shared-assets
- `npx markdownlint-cli2 README.md RELEASE.md TESTING.md OPENSSF.md` across rollout repositories
- acceptance scan for no `(none)`, `undefined`, `null`, placeholder badge text, collapsed README lines, or generated symlinks
