### PR TITLE
chore: sync final Copilot review gate

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -191,6 +191,11 @@ jobs:
             done
           }
 
+          # A rejected review cannot become acceptable during this run without
+          # an edit event, which starts a fresh run through the concurrency
+          # group. Cache rejected IDs so marker-only reviews cost one detail
+          # query per run instead of one query on every polling attempt.
+          declare -A rejected_review_ids=()
           review_complete=false
           head_sha=""
           for attempt in $(seq 1 40); do
@@ -242,6 +247,9 @@ jobs:
                 if [ -z "${review_id}" ]; then
                   continue
                 fi
+                if [ -n "${rejected_review_ids[${review_id}]:-}" ]; then
+                  continue
+                fi
                 if review_comments_clean "${review_id}" "${head_sha}"; then
                   review_complete=true
                   break
@@ -251,6 +259,7 @@ jobs:
                     request_failed=true
                     break
                   fi
+                  rejected_review_ids["${review_id}"]=1
                 fi
               done <<<"${candidate_review_ids}"
               if [ "${review_complete}" = true ]; then

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -43,19 +43,6 @@ jobs:
 
           owner="${REPOSITORY%%/*}"
           repository="${REPOSITORY#*/}"
-          normalize_review_marker() {
-            jq -Rr '
-              ascii_downcase
-              | gsub("wasn[\u0027\u2019]t"; "was not")
-              | gsub("\\s"; "")
-            ' <<<"$1"
-          }
-          normalized_unable_review_marker="$(
-            normalize_review_marker "${UNABLE_REVIEW_MARKER}"
-          )"
-          normalized_no_files_review_marker="$(
-            normalize_review_marker "${NO_FILES_REVIEW_MARKER}"
-          )"
 
           graphql() {
             local api_attempt output
@@ -88,8 +75,6 @@ jobs:
                   nodes {
                     id
                     author { login }
-                    body
-                    comments(first: 1) { totalCount }
                     commit { oid }
                     state
                   }
@@ -147,8 +132,8 @@ jobs:
 
               if ! content_counts="$(
                 jq -er \
-                  --arg unable_marker "${normalized_unable_review_marker}" \
-                  --arg no_files_marker "${normalized_no_files_review_marker}" \
+                  --arg unable_marker "${UNABLE_REVIEW_MARKER}" \
+                  --arg no_files_marker "${NO_FILES_REVIEW_MARKER}" \
                   'def normalize_review_text:
                       ascii_downcase
                       | gsub("wasn[\u0027\u2019]t"; "was not")
@@ -156,14 +141,16 @@ jobs:
                   def review_content:
                       (.data.node.body // ""),
                       (.data.node.comments.nodes[]?.body // "");
-                  [
+                  ($unable_marker | normalize_review_text) as $unable
+                  | ($no_files_marker | normalize_review_text) as $no_files
+                  | [
                     ([
                       review_content
                       | select(
                           normalize_review_text
                           | (
-                              contains($unable_marker)
-                              or contains($no_files_marker)
+                              contains($unable)
+                              or contains($no_files)
                             )
                         )
                     ] | length),
@@ -242,29 +229,12 @@ jobs:
                 jq -r \
                   --arg head "${head_sha}" \
                   --arg reviewer "${COPILOT_REVIEWER_LOGIN}" \
-                  --arg unable_marker "${normalized_unable_review_marker}" \
-                  --arg no_files_marker "${normalized_no_files_review_marker}" \
-                  'def normalize_review_text:
-                      ascii_downcase
-                      | gsub("wasn[\u0027\u2019]t"; "was not")
-                      | gsub("\\s"; "");
-                  (.data.repository.pullRequest.reviews.nodes // [])[]
+                  '(.data.repository.pullRequest.reviews.nodes // [])[]
                     | select(
                         (.author.login // "") as $login
                         | ($login == $reviewer or $login == ($reviewer + "[bot]"))
                       )
                     | select(.state == "COMMENTED")
-                    | select(
-                        (((.body // "") | gsub("\\s"; "")) != "")
-                        or ((.comments.totalCount // 0) > 0)
-                      )
-                    | select(
-                        ((.body // "") | normalize_review_text) as $body
-                        | (
-                            ($body | contains($unable_marker))
-                            or ($body | contains($no_files_marker))
-                          ) == false
-                      )
                     | select(.commit.oid == $head)
                     | .id' <<<"${response}"
               )"

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -18,6 +18,7 @@ permissions:
 
 env:
   COPILOT_REVIEWER_LOGIN: copilot-pull-request-reviewer
+  NO_FILES_REVIEW_MARKER: was not able to review any files
   UNABLE_REVIEW_MARKER: unable to review this pull request
 
 concurrency:
@@ -42,10 +43,18 @@ jobs:
 
           owner="${REPOSITORY%%/*}"
           repository="${REPOSITORY#*/}"
+          normalize_review_marker() {
+            jq -Rr '
+              ascii_downcase
+              | gsub("wasn[\u0027\u2019]t"; "was not")
+              | gsub("\\s"; "")
+            ' <<<"$1"
+          }
           normalized_unable_review_marker="$(
-            jq -nr \
-              --arg marker "${UNABLE_REVIEW_MARKER}" \
-              '$marker | ascii_downcase | gsub("\\s"; "")'
+            normalize_review_marker "${UNABLE_REVIEW_MARKER}"
+          )"
+          normalized_no_files_review_marker="$(
+            normalize_review_marker "${NO_FILES_REVIEW_MARKER}"
           )"
 
           graphql() {
@@ -111,7 +120,8 @@ jobs:
 
           review_comments_clean() {
             local review_id="$1" expected_head="$2" after="" response has_next
-            local marker_count content_count meaningful_content=false
+            local content_counts marker_count content_count meaningful_content=false
+            local count_pattern=$'^[0-9]+\t[0-9]+$'
             local -a arguments
             while true; do
               arguments=(
@@ -135,19 +145,26 @@ jobs:
                 return 2
               fi
 
-              read -r marker_count content_count <<<"$(
-                jq -r \
-                  --arg marker "${normalized_unable_review_marker}" \
-                  'def review_content:
+              if ! content_counts="$(
+                jq -er \
+                  --arg unable_marker "${normalized_unable_review_marker}" \
+                  --arg no_files_marker "${normalized_no_files_review_marker}" \
+                  'def normalize_review_text:
+                      ascii_downcase
+                      | gsub("wasn[\u0027\u2019]t"; "was not")
+                      | gsub("\\s"; "");
+                  def review_content:
                       (.data.node.body // ""),
                       (.data.node.comments.nodes[]?.body // "");
                   [
                     ([
                       review_content
                       | select(
-                          ascii_downcase
-                          | gsub("\\s"; "")
-                          | contains($marker)
+                          normalize_review_text
+                          | (
+                              contains($unable_marker)
+                              or contains($no_files_marker)
+                            )
                         )
                     ] | length),
                     ([
@@ -156,7 +173,15 @@ jobs:
                     ] | length)
                   ]
                   | @tsv' <<<"${response}"
-              )"
+              )"; then
+                echo "Unable to parse review content counts for review ${review_id}; refusing to accept the review." >&2
+                return 2
+              fi
+              if [[ ! "${content_counts}" =~ ${count_pattern} ]]; then
+                echo "Review ${review_id} returned invalid review content counts; refusing to accept the review." >&2
+                return 2
+              fi
+              IFS=$'\t' read -r marker_count content_count <<<"${content_counts}"
               if [ "${marker_count}" -gt 0 ]; then
                 return 1
               fi
@@ -217,8 +242,13 @@ jobs:
                 jq -r \
                   --arg head "${head_sha}" \
                   --arg reviewer "${COPILOT_REVIEWER_LOGIN}" \
-                  --arg marker "${normalized_unable_review_marker}" \
-                  '(.data.repository.pullRequest.reviews.nodes // [])[]
+                  --arg unable_marker "${normalized_unable_review_marker}" \
+                  --arg no_files_marker "${normalized_no_files_review_marker}" \
+                  'def normalize_review_text:
+                      ascii_downcase
+                      | gsub("wasn[\u0027\u2019]t"; "was not")
+                      | gsub("\\s"; "");
+                  (.data.repository.pullRequest.reviews.nodes // [])[]
                     | select(
                         (.author.login // "") as $login
                         | ($login == $reviewer or $login == ($reviewer + "[bot]"))
@@ -229,10 +259,11 @@ jobs:
                         or ((.comments.totalCount // 0) > 0)
                       )
                     | select(
-                        ((.body // "")
-                        | ascii_downcase
-                        | gsub("\\s"; "")
-                        | contains($marker)) == false
+                        ((.body // "") | normalize_review_text) as $body
+                        | (
+                            ($body | contains($unable_marker))
+                            or ($body | contains($no_files_marker))
+                          ) == false
                       )
                     | select(.commit.oid == $head)
                     | .id' <<<"${response}"

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -97,6 +97,7 @@ jobs:
           ) {
             node(id: $review) {
               ... on PullRequestReview {
+                body
                 commit { oid }
                 pullRequest { headRefOid }
                 comments(first: 100, after: $after) {
@@ -109,7 +110,8 @@ jobs:
           GRAPHQL
 
           review_comments_clean() {
-            local review_id="$1" expected_head="$2" after="" response has_next marker_count
+            local review_id="$1" expected_head="$2" after="" response has_next
+            local marker_count content_count meaningful_content=false
             local -a arguments
             while true; do
               arguments=(
@@ -133,27 +135,41 @@ jobs:
                 return 2
               fi
 
-              marker_count="$(
-                jq \
+              read -r marker_count content_count <<<"$(
+                jq -r \
                   --arg marker "${normalized_unable_review_marker}" \
-                  '[
-                    .data.node.comments.nodes[]?
-                    | select(
-                        ((.body // "")
-                        | ascii_downcase
-                        | gsub("\\s"; "")
-                        | contains($marker))
-                      )
+                  'def review_content:
+                      (.data.node.body // ""),
+                      (.data.node.comments.nodes[]?.body // "");
+                  [
+                    ([
+                      review_content
+                      | select(
+                          ascii_downcase
+                          | gsub("\\s"; "")
+                          | contains($marker)
+                        )
+                    ] | length),
+                    ([
+                      review_content
+                      | select((gsub("\\s"; "")) != "")
+                    ] | length)
                   ]
-                  | length' <<<"${response}"
+                  | @tsv' <<<"${response}"
               )"
               if [ "${marker_count}" -gt 0 ]; then
                 return 1
               fi
+              if [ "${content_count}" -gt 0 ]; then
+                meaningful_content=true
+              fi
 
               has_next="$(jq -r '.data.node.comments.pageInfo.hasNextPage' <<<"${response}")"
               if [ "${has_next}" != "true" ]; then
-                return 0
+                if [ "${meaningful_content}" = true ]; then
+                  return 0
+                fi
+                return 1
               fi
               after="$(jq -r '.data.node.comments.pageInfo.endCursor // empty' <<<"${response}")"
               if [ -z "${after}" ]; then


### PR DESCRIPTION
Final narrow sync from `lightning-it/shared-assets-lit` after canonical PRs #288-#297. This updates only the fail-closed Copilot review gate; the PR remains draft until released into a bounded current-SHA review batch.