### PR TITLE
docs(governance): record collection assurance controls

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+* @lightning-it/ent:release
+/.github/ @lightning-it/ent:release
+/galaxy.yml @lightning-it/ent:release
+/meta/ @lightning-it/ent:release
+/roles/ @lightning-it/ent:release
+/scripts/ @lightning-it/ent:release

--- a/OPENSSF.md
+++ b/OPENSSF.md
@@ -8,8 +8,12 @@ This repository follows the Lightning IT shared OpenSSF readiness model generate
 - [Branching, Review and Release Governance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878603438)
 - [Mandatory CI Quality and Artifact Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878636340)
 - [Distributed Test Ownership and Central Heavy Execution](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886566105)
+- [ModuLix Lifecycle, Versioning and Release Evidence](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886926524)
 - [Repository and Secure SDLC Standard](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887778335)
+- [Technology Engineering Standards](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886762765)
+- [Quality Gates and Definition of Done](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887123058)
 - [OpenSSF and Software Supply Chain Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887024876)
+- [Compliance Gaps and Migration Roadmap](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886926554)
 
 ## Repository
 

--- a/OPENSSF.md
+++ b/OPENSSF.md
@@ -2,6 +2,15 @@
 
 This repository follows the Lightning IT shared OpenSSF readiness model generated from `lightning-it/shared-assets-lit`.
 
+## Governing Decisions And Standards
+
+- [Repository Topology and Shared Engineering Assets](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878636297)
+- [Branching, Review and Release Governance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878603438)
+- [Mandatory CI Quality and Artifact Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878636340)
+- [Distributed Test Ownership and Central Heavy Execution](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886566105)
+- [Repository and Secure SDLC Standard](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887778335)
+- [OpenSSF and Software Supply Chain Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887024876)
+
 ## Repository
 
 - Repository: `ansible-collection-ocp`
@@ -47,3 +56,5 @@ ansible-lint, yamllint, changelog checks, collection build/smoke validation, and
 ## Exceptions
 
 Repository-specific exceptions must be documented in this file or in `.lit/repository.yml`. Exceptions must not expose secrets, private infrastructure details, customer data, or credential-bearing examples.
+
+The current Galaxy release path records and remotely verifies the immutable collection tarball SHA-256, but does not yet attach a CycloneDX SBOM, signed checksum bundle, or GitHub provenance attestation. Migration target: the verified `ansible-collection-supplementary` release-evidence model. Exception owner: `@lightning-it/ent:release`; compensating controls: protected exact-SHA release flow, candidate build/install tests, Galaxy post-publish digest verification, and immutable GitHub Release assets; review/expiry: `2026-10-31`.

--- a/changelogs/fragments/adr-assurance.yml
+++ b/changelogs/fragments/adr-assurance.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Document the governing enterprise ADRs and assign repository ownership for their enforcement.


### PR DESCRIPTION
Tracks #268. Adds CODEOWNERS and direct ADR/standard references. The current Galaxy path verifies SHA-256 before and after publication; the missing CycloneDX/signature/provenance bundle is recorded as an expiring review-required waiver through 2026-10-31 with compensating controls and the supplementary collection model as migration target. CI will provide lint, build/install, Molecule and release dry-run evidence. Central CODEOWNERS enforcement is in lightning-it/github-management-lit#183.