### PR TITLE
fix: resolve release and TLS review findings

### DIFF
--- a/.github/workflows/release-back-sync.yml
+++ b/.github/workflows/release-back-sync.yml
@@ -60,11 +60,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          bot_login="$(gh api "users/lightning-it-release-automation%5Bbot%5D" --jq .login)"
+          bot_json="$(gh api "users/lightning-it-release-automation%5Bbot%5D")"
+          bot_login="$(jq -r '.login' <<<"$bot_json")"
+          bot_id="$(jq -r '.id' <<<"$bot_json")"
           if [ "$bot_login" != "lightning-it-release-automation[bot]" ]; then
             echo "::error::Release App identity mismatch: expected lightning-it-release-automation[bot]."
             exit 1
           fi
+          if ! [[ "$bot_id" =~ ^[0-9]+$ ]]; then
+            echo "::error::Release App identity has no valid numeric GitHub user ID."
+            exit 1
+          fi
+          bot_email="${bot_id}+${bot_login}@users.noreply.github.com"
           gh auth setup-git
 
           tag="${RELEASE_TAG:-${TAG_INPUT:-}}"
@@ -82,8 +89,8 @@ jobs:
             exit 0
           fi
 
-          git config user.name "lightning-it-release-automation[bot]"
-          git config user.email "307565056+lightning-it-release-automation[bot]@users.noreply.github.com"
+          git config user.name "$bot_login"
+          git config user.email "$bot_email"
           git fetch origin main develop
 
           if git merge-base --is-ancestor origin/main origin/develop; then

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -101,11 +101,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          bot_login="$(gh api "users/lightning-it-release-automation%5Bbot%5D" --jq .login)"
+          bot_json="$(gh api "users/lightning-it-release-automation%5Bbot%5D")"
+          bot_login="$(jq -r '.login' <<<"$bot_json")"
+          bot_id="$(jq -r '.id' <<<"$bot_json")"
           if [ "$bot_login" != "lightning-it-release-automation[bot]" ]; then
             echo "::error::Release App identity mismatch: expected lightning-it-release-automation[bot]."
             exit 1
           fi
+          if ! [[ "$bot_id" =~ ^[0-9]+$ ]]; then
+            echo "::error::Release App identity has no valid numeric GitHub user ID."
+            exit 1
+          fi
+          bot_email="${bot_id}+${bot_login}@users.noreply.github.com"
           gh auth setup-git
 
           VERSION="${VERSION_INPUT:-}"
@@ -130,8 +137,8 @@ jobs:
             exit 1
           fi
 
-          git config user.name "lightning-it-release-automation[bot]"
-          git config user.email "307565056+lightning-it-release-automation[bot]@users.noreply.github.com"
+          git config user.name "$bot_login"
+          git config user.email "$bot_email"
           git fetch origin "$BASE_BRANCH" "$TARGET_BRANCH"
           git switch -C release-prepare-base "origin/$BASE_BRANCH"
 

--- a/changelogs/fragments/gitops-bootstrap-tls-cleanup.yml
+++ b/changelogs/fragments/gitops-bootstrap-tls-cleanup.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Remove the managed Argo CD trusted TLS certificate ConfigMap when no TLS
+    certificates are configured or the GitOps operator is removed, preventing
+    stale trust configuration.

--- a/roles/gitops_bootstrap/tasks/main.yml
+++ b/roles/gitops_bootstrap/tasks/main.yml
@@ -212,7 +212,20 @@
     _gitops_bootstrap_vault_secret: "{{ item.value.vault_secret | trim }}"
   no_log: true
 
-- name: Create tls config
+- name: Remove tls config when it is not configured
+  delegate_to: localhost
+  run_once: true
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: ConfigMap
+    name: argocd-tls-certs-cm
+    namespace: openshift-gitops
+  when: >-
+    gitops_bootstrap_operator_state == 'absent'
+    or (gitops_bootstrap_tls_certs | default([]) | length == 0)
+
+- name: Create tls config when it is configured
   delegate_to: localhost
   run_once: true
   kubernetes.core.k8s:


### PR DESCRIPTION
## What changed

- derive the release bot Git author name and noreply address from GitHub's verified App user response
- reject an invalid or non-numeric App user ID before creating release commits
- remove the managed Argo CD TLS ConfigMap when TLS certificates are empty or the operator is removed

## Why

This resolves the actionable review findings on the `develop` to `main` promotion PR and prevents stale configuration as well as brittle hard-coded bot identity metadata.

## Validation

- `git diff --check`
- `yamllint .github/workflows/release-prepare.yml .github/workflows/release-back-sync.yml roles/gitops_bootstrap/tasks/main.yml`
- `ansible-lint roles/gitops_bootstrap/tasks/main.yml`

Relates to #268 and #276.
